### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plugin enables Aliyun Function Compute support within the Serverless Framew
 You can install the following example via:
 
 ```console
-serverless install --url https://github.com/aliyun/serverless-function-compute-examples/tree/master/aliyun-nodej
+serverless install --url https://github.com/aliyun/serverless-function-compute-examples/tree/master/aliyun-nodejs
 ```
 
 The structure of the project should look something like this:


### PR DESCRIPTION
I think this is "aliyun-nodejs", not "aliyun-nodej"
我认为这里说的是 "aliyun-nodejs" 而不是 "aliyun-nodej"