### PR TITLE
Allow envrionment variable passthru

### DIFF
--- a/provider/aliyunProvider.js
+++ b/provider/aliyunProvider.js
@@ -371,7 +371,8 @@ class AliyunProvider {
         'code': {
           'ossBucketName': this.getDeploymentBucketName(),
           'ossObjectName': service.package.artifactFilePath
-        }
+        },
+        'environmentVariables': funcObject.environmentVariables
       }
     };
   }


### PR DESCRIPTION
Allow user to specify runtime environment variables in `serverless.yml`, for example:

```yaml
custom:
  myVariable: 'some value'
functions:
  myFunction:
    handler: src/myFunction.handle
    environmentVariables:
      MY_VARIABLE: "${self:custom.myVariable}"
```